### PR TITLE
perf: All models have been changed from basic ner to beam_ner with be…

### DIFF
--- a/hu_core_news_lg/configs/ner.cfg
+++ b/hu_core_news_lg/configs/ner.cfg
@@ -62,7 +62,8 @@ window_size = 2
 maxout_pieces = 5
 
 [components.ner]
-factory = "ner"
+factory = "beam_ner"
+beam_update_prob = 1
 moves = null
 update_with_oracle_cut_size = 100
 

--- a/hu_core_news_md/configs/ner.cfg
+++ b/hu_core_news_md/configs/ner.cfg
@@ -62,7 +62,8 @@ window_size = 2
 maxout_pieces = 5
 
 [components.ner]
-factory = "ner"
+factory = "beam_ner"
+beam_update_prob = 1
 moves = null
 update_with_oracle_cut_size = 100
 

--- a/hu_core_news_trf/configs/ner.cfg
+++ b/hu_core_news_trf/configs/ner.cfg
@@ -23,6 +23,7 @@ tokenizer = {"@tokenizers":"spacy.Tokenizer.v1"}
 
 [components.ner]
 factory = "beam_ner"
+beam_update_prob = 1
 incorrect_spans_key = null
 moves = null
 scorer = {"@scorers":"spacy.ner_scorer.v1"}


### PR DESCRIPTION
…am_update_prob = 1 feature

beam_ner is **half a percentage point** more accurate than base ner, and the throughput is very minimally less
| |Token/sec|
|-|-|
|beam_ner|628 sec|
|base ner|659 sec|


<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here, if any. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes # .

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->


## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.

